### PR TITLE
fix: split element names to hanle multiple kos

### DIFF
--- a/gem_utilities/maps.py
+++ b/gem_utilities/maps.py
@@ -47,10 +47,15 @@ def map_ko_ids(
 
     # Make all squares white, except for the ones with the KO identifiers
     for element in pathway.orthologs:
-        for graphic in element.graphics:
-            if graphic.name in ko_ids:
+        # Clean up the list of orthologs associated with each element
+        element_orthologs = set(p.split("ko:")[1] for p in element._names)
+        # See if there are any orthologs from the element present in the
+        # supplied list to color
+        if element_orthologs & ko_ids:
+            for graphic in element.graphics:
                 graphic.bgcolor = color
-            else:
+        else:
+            for graphic in element.graphics:
                 graphic.bgcolor = "#FFFFFF"
 
     # Render the map


### PR DESCRIPTION
This fixes an error in the ko plotting that was causing KEGG maps to be incorrectly empty. The error can from pathway "elements" having multiple orthologs in a single string as the name. That name needed to be split, and the prefix "ko" removed to be able to match to the KOs provided in the model.